### PR TITLE
Add check to palette file print (#1)

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,9 @@ module.exports = (opts = { }) => {
 				}
 			},
 			OnceExit () {
-				fs.writeFile('inc/editor-color-palette.json', JSON.stringify(colorJson), function(){});
+        if (!(Object.keys(colorJson).length === 0)){
+          fs.writeFile('inc/editor-color-palette.json', JSON.stringify(colorJson), function(){});
+        }
 				return colorJson;
 			}
 		}


### PR DESCRIPTION
This PR adds a condition to prevent writing the empty braces to the editor-color-palette.json file.

Running the css-bs4 occasionally generated the color-palette file with empty braces at the beginning.
![ErrantBraces](https://user-images.githubusercontent.com/7034826/136215982-73e9933e-db52-4217-b893-26e327875a45.PNG)

This caused an error in WordPress that breaks customizer.
![Customizer changeset error](https://user-images.githubusercontent.com/7034826/136216063-6b29f38a-c079-4a53-ae2e-b1d2deefd7ff.PNG)

